### PR TITLE
Implement entity saving

### DIFF
--- a/studyzen/Common/BaseEntity.cs
+++ b/studyzen/Common/BaseEntity.cs
@@ -1,0 +1,11 @@
+﻿namespace StudyZen.Common;
+
+public abstract class BaseEntity
+{
+    public int Id { get; set; }
+
+    protected BaseEntity(int id)
+    {
+        Id = id;
+    }
+}

--- a/studyzen/Common/Exceptions/InstanceNotFoundException.cs
+++ b/studyzen/Common/Exceptions/InstanceNotFoundException.cs
@@ -1,0 +1,9 @@
+﻿namespace StudyZen.Common.Exceptions;
+
+public sealed class InstanceNotFoundException : Exception
+{
+    public InstanceNotFoundException(string entityName, int id)
+        : base($"Could not find an instance of '{entityName}' by id {id}.")
+    {
+    }
+}

--- a/studyzen/Common/Exceptions/RequestArgumentNullException.cs
+++ b/studyzen/Common/Exceptions/RequestArgumentNullException.cs
@@ -1,4 +1,4 @@
-﻿namespace Studyzen.Common.Errors;
+﻿namespace StudyZen.Common.Exceptions;
 
 public sealed class RequestArgumentNullException : ArgumentNullException
 {

--- a/studyzen/Common/Utilities.cs
+++ b/studyzen/Common/Utilities.cs
@@ -1,6 +1,7 @@
-﻿using Studyzen.Common.Errors;
+﻿using Newtonsoft.Json;
+using StudyZen.Common.Exceptions;
 
-namespace Studyzen.Common;
+namespace StudyZen.Common;
 
 public static class Utilities
 {
@@ -9,12 +10,29 @@ public static class Utilities
         if (obj is null)
         {
             throw new RequestArgumentNullException(
-                paramName,
-                paramName is null
-                    ? null
-                    : $"Request argument '{paramName}' is null.");
+                paramName, paramName is null ? null : $"Request argument '{paramName}' is null.");
         }
 
         return obj;
+    }
+
+    public static void WriteToJsonFile<T>(string filePath, T objectToWrite)
+    {
+        using var writer = new StreamWriter(filePath, false);
+        var contentsToWrite = JsonConvert.SerializeObject(objectToWrite, Formatting.Indented);
+
+        writer.Write(contentsToWrite);
+        writer.Flush();
+        writer.Close();
+    }
+
+    public static T? ReadFromJsonFile<T>(string filePath)
+    {
+        using var reader = new StreamReader(filePath);
+
+        var fileContents = reader.ReadToEnd();
+        reader.Close();
+
+        return JsonConvert.DeserializeObject<T>(fileContents);
     }
 }

--- a/studyzen/Courses/Course.cs
+++ b/studyzen/Courses/Course.cs
@@ -1,14 +1,14 @@
-﻿namespace Studyzen.Courses;
+﻿using StudyZen.Common;
 
-public sealed class Course
+namespace StudyZen.Courses;
+
+public sealed class Course : BaseEntity
 {
-    public int Id { get; }
     public string Name { get; set; }
     public string Description { get; set; }
 
-    public Course(int id, string name, string description)
+    public Course(string name, string description) : base(default)
     {
-        Id = id;
         Name = name;
         Description = description;
     }

--- a/studyzen/Courses/CourseService.cs
+++ b/studyzen/Courses/CourseService.cs
@@ -19,8 +19,6 @@ public sealed class CourseService : ICourseService
 
     public int AddCourse(CreateCourseRequest request)
     {
-        _unitOfWork.Courses.Update(new Course("", ""));
-
         throw new NotImplementedException();
     }
 }

--- a/studyzen/Courses/CourseService.cs
+++ b/studyzen/Courses/CourseService.cs
@@ -1,18 +1,26 @@
-﻿using Studyzen.Courses.Requests;
+﻿using StudyZen.Courses.Requests;
+using StudyZen.Persistence;
 
-namespace Studyzen.Courses;
+namespace StudyZen.Courses;
 
 public interface ICourseService
 {
-    Task<int> AddCourseAsync(CreateCourseRequest request);
+    int AddCourse(CreateCourseRequest request);
 }
 
 public sealed class CourseService : ICourseService
 {
-    public async Task<int> AddCourseAsync(CreateCourseRequest request)
-    {
-        var course = new Course(default, request.Name, request.Description);
+    private readonly IUnitOfWork _unitOfWork;
 
-        return course.Id;
+    public CourseService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public int AddCourse(CreateCourseRequest request)
+    {
+        _unitOfWork.Courses.Update(new Course("", ""));
+
+        throw new NotImplementedException();
     }
 }

--- a/studyzen/Courses/CoursesController.cs
+++ b/studyzen/Courses/CoursesController.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Studyzen.Common;
-using Studyzen.Courses.Requests;
+using StudyZen.Common;
+using StudyZen.Courses.Requests;
 
-namespace Studyzen.Courses;
+namespace StudyZen.Courses;
 
+[ApiController]
 [Route("[controller]")]
 public sealed class CoursesController : ControllerBase
 {
@@ -15,11 +16,11 @@ public sealed class CoursesController : ControllerBase
     }
 
     [HttpPost]
-    public async Task<IActionResult> CreateCourse([FromBody] CreateCourseRequest? request)
+    public IActionResult CreateCourse([FromBody] CreateCourseRequest? request)
     {
         request = request.ThrowIfRequestArgumentNull(nameof(request));
 
-        var courseId = _courseService.AddCourseAsync(request);
+        var courseId = _courseService.AddCourse(request);
 
         return CreatedAtAction(nameof(GetCourse), new { courseId = courseId }, null);
     }

--- a/studyzen/Courses/Requests/CreateCourseRequest.cs
+++ b/studyzen/Courses/Requests/CreateCourseRequest.cs
@@ -1,8 +1,8 @@
-﻿using Studyzen.Common;
+﻿using StudyZen.Common;
 
-namespace Studyzen.Courses.Requests;
+namespace StudyZen.Courses.Requests;
 
-public sealed record CreateCourseRequest
+public sealed class CreateCourseRequest
 {
     public string Name { get; }
     public string Description { get; }

--- a/studyzen/Persistence/EntitySet.cs
+++ b/studyzen/Persistence/EntitySet.cs
@@ -1,0 +1,7 @@
+﻿namespace StudyZen.Persistence;
+
+public sealed class EntitySet<TEntity>
+{
+    public int TotalCount { get; set; }
+    public List<TEntity> Instances { get; } = new();
+}

--- a/studyzen/Persistence/GenericRepository.cs
+++ b/studyzen/Persistence/GenericRepository.cs
@@ -1,0 +1,95 @@
+﻿using StudyZen.Common;
+using StudyZen.Common.Exceptions;
+
+namespace StudyZen.Persistence;
+
+public interface IGenericRepository<TEntity> where TEntity : BaseEntity
+{
+    void Add(TEntity instance);
+    TEntity? GetById(int instanceId);
+    List<TEntity> GetAll();
+    void Update(TEntity instance);
+    void Delete(int instanceId);
+}
+
+public class GenericRepository<TEntity> : IGenericRepository<TEntity> where TEntity : BaseEntity
+{
+    private readonly string _filePath;
+
+    public GenericRepository(string fileName)
+    {
+        _filePath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "StudyZen",
+            $"{fileName}.json");
+    }
+
+    public void Add(TEntity instance)
+    {
+        var entitySet = GetEntitySet();
+
+        instance.Id = ++entitySet.TotalCount;
+        entitySet.Instances.Add(instance);
+
+        Utilities.WriteToJsonFile(_filePath, entitySet);
+    }
+
+    public TEntity? GetById(int instanceId)
+    {
+        return GetAll().FirstOrDefault(i => i.Id == instanceId);
+    }
+
+    public List<TEntity> GetAll()
+    {
+        return GetEntitySet().Instances;
+    }
+
+    public void Update(TEntity instance)
+    {
+        var entitySet = GetEntitySet();
+
+        var instanceIdx = entitySet.Instances.FindIndex(i => i.Id == instance.Id);
+        if (instanceIdx < 0)
+        {
+            throw new InstanceNotFoundException(typeof(TEntity).Name, instance.Id);
+        }
+
+        entitySet.Instances[instanceIdx] = instance;
+
+        Utilities.WriteToJsonFile(_filePath, entitySet);
+    }
+
+    public void Delete(int instanceId)
+    {
+        var entitySet = GetEntitySet();
+
+        var instance = entitySet.Instances.FirstOrDefault(i => i.Id == instanceId);
+        if (instance is null)
+        {
+            return;
+        }
+
+        entitySet.Instances.Remove(instance);
+
+        Utilities.WriteToJsonFile(_filePath, entitySet);
+    }
+
+    private EntitySet<TEntity> GetEntitySet()
+    {
+        EnsureFileCreated();
+
+        var entitySet = Utilities.ReadFromJsonFile<EntitySet<TEntity>>(_filePath) ?? new EntitySet<TEntity>();
+
+        return entitySet;
+    }
+
+    private void EnsureFileCreated()
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_filePath)!);
+
+        if (!File.Exists(_filePath))
+        {
+            File.Create(_filePath).Close();
+        }
+    }
+}

--- a/studyzen/Persistence/UnitOfWork.cs
+++ b/studyzen/Persistence/UnitOfWork.cs
@@ -1,0 +1,18 @@
+﻿using StudyZen.Courses;
+
+namespace StudyZen.Persistence;
+
+public interface IUnitOfWork
+{
+    IGenericRepository<Course> Courses { get; }
+}
+
+public sealed class UnitOfWork : IUnitOfWork
+{
+    public IGenericRepository<Course> Courses { get; }
+
+    public UnitOfWork()
+    {
+        Courses = new GenericRepository<Course>("courses");
+    }
+}

--- a/studyzen/Program.cs
+++ b/studyzen/Program.cs
@@ -1,20 +1,26 @@
 using System.Text.Json.Serialization;
 using Hellang.Middleware.ProblemDetails;
 using Hellang.Middleware.ProblemDetails.Mvc;
-using Studyzen.Common.Errors;
-using Studyzen.Courses;
+using StudyZen.Common.Exceptions;
+using StudyZen.Courses;
+using StudyZen.Persistence;
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 builder.Services
-    .AddProblemDetails(options => { options.MapToStatusCode<RequestArgumentNullException>(StatusCodes.Status400BadRequest); })
+    .AddProblemDetails(options =>
+    {
+        options.MapToStatusCode<RequestArgumentNullException>(StatusCodes.Status400BadRequest);
+        options.MapToStatusCode<InstanceNotFoundException>(StatusCodes.Status404NotFound);
+    })
     .AddControllers()
     .AddProblemDetailsConventions()
     .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
 ProblemDetailsExtensions.AddProblemDetails(builder.Services);
 
+builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<ICourseService, CourseService>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle

--- a/studyzen/studyzen.csproj
+++ b/studyzen/studyzen.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<RootNamespace>Studyzen</RootNamespace>
-		<AssemblyName>Studyzen</AssemblyName>
+		<RootNamespace>StudyZen</RootNamespace>
+		<AssemblyName>StudyZen</AssemblyName>
 		<TargetFramework>net7.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -12,6 +12,7 @@
 		<PackageReference Include="Hellang.Middleware.ProblemDetails" Version="6.5.1" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 

--- a/studyzen/studyzen.sln
+++ b/studyzen/studyzen.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33502.453
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "studyzen", "studyzen.csproj", "{EA17CBC5-60E8-4A61-B676-8C1C0FD39640}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "StudyZen", "StudyZen.csproj", "{EA17CBC5-60E8-4A61-B676-8C1C0FD39640}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
- Added generic entity saving in a JSON file, tested it, should work fine. If you run into any issues, please contact.
- JSON files will be saved in your `%appdata%/StudyZen`;
- How to use it (there is kind of an example with `Course` class):
  - Your class must derive from `BaseEntity`
  - Add your `GenericRepository` of your class type to `UnitOfWork`
  - Access `UnitOfWork` in your class via Dependency Injection
  - If your class contains a relationship, **DO NOT** include related objects to avoid data inconsistency. E.g. a course can contain many lectures, but don't add `List<Lecture>`; instead get all lectures and filter them by foreign key.
  - `Id` field will be assigned automatically, when saving the object