### PR TITLE
Add entity constraints

### DIFF
--- a/server/src/Api/DependencyInjection.cs
+++ b/server/src/Api/DependencyInjection.cs
@@ -27,6 +27,7 @@ public static class DependencyInjection
                 options.MapToStatusCode<ValidationException>(StatusCodes.Status422UnprocessableEntity);
             })
             .AddControllers()
+            .ConfigureApiBehaviorOptions(options => options.SuppressModelStateInvalidFilter = true)
             .AddProblemDetailsConventions()
             .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 

--- a/server/src/Api/DependencyInjection.cs
+++ b/server/src/Api/DependencyInjection.cs
@@ -1,7 +1,7 @@
-﻿using Hellang.Middleware.ProblemDetails;
+﻿using FluentValidation;
+using Hellang.Middleware.ProblemDetails;
 using Hellang.Middleware.ProblemDetails.Mvc;
 using StudyZen.Api.Exceptions;
-using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace StudyZen.Api;

--- a/server/src/Application/Validation/ValidationErrorCodes.cs
+++ b/server/src/Application/Validation/ValidationErrorCodes.cs
@@ -2,8 +2,8 @@
 
 public static class ValidationErrorCodes
 {
-    public const string MustNotBeNull = "MustNotBeNull";
-    public const string MustNotBeEmpty = "MustNotBeEmpty";
-    public const string TooLong = "TooLong";
+    public const string Null = "Null";
+    public const string NullOrWhitespace = "NullOrWhitespace";
+    public const string MaxLength = "MaxLength";
     public const string NotFound = "NotFound";
 }

--- a/server/src/Application/Validation/ValidationErrorCodes.cs
+++ b/server/src/Application/Validation/ValidationErrorCodes.cs
@@ -4,7 +4,6 @@ public static class ValidationErrorCodes
 {
     public const string MustNotBeNull = "MustNotBeNull";
     public const string MustNotBeEmpty = "MustNotBeEmpty";
-    public const string TooShort = "TooShort";
     public const string TooLong = "TooLong";
     public const string NotFound = "NotFound";
 }

--- a/server/src/Application/Validation/ValidationErrorCodes.cs
+++ b/server/src/Application/Validation/ValidationErrorCodes.cs
@@ -1,0 +1,10 @@
+﻿namespace StudyZen.Application.Validation;
+
+public static class ValidationErrorCodes
+{
+    public const string MustNotBeNull = "MustNotBeNull";
+    public const string MustNotBeEmpty = "MustNotBeEmpty";
+    public const string TooShort = "TooShort";
+    public const string TooLong = "TooLong";
+    public const string NotFound = "NotFound";
+}

--- a/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
@@ -1,0 +1,37 @@
+﻿using FluentValidation;
+using StudyZen.Application.Services;
+using StudyZen.Domain.Constraints;
+
+namespace StudyZen.Application.Validation;
+
+public static class CourseValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> CourseName<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
+            .MinimumLength(CourseConstraints.NameMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(CourseConstraints.NameMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, string?> CourseDescription<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotNull()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
+            .MinimumLength(CourseConstraints.DescriptionMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(CourseConstraints.DescriptionMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, int> CourseId<T>(this IRuleBuilder<T, int> ruleBuilder, ICourseService courseService)
+    {
+        return ruleBuilder
+            .Must(id => courseService.GetCourseById(id) is not null)
+            .WithErrorCode(ValidationErrorCodes.NotFound);
+    }
+}

--- a/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
@@ -11,8 +11,6 @@ public static class CourseValidationExtensions
         return ruleBuilder
             .NotEmpty()
             .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MinimumLength(CourseConstraints.NameMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
             .MaximumLength(CourseConstraints.NameMaxLength)
             .WithErrorCode(ValidationErrorCodes.TooLong);
     }
@@ -22,8 +20,6 @@ public static class CourseValidationExtensions
         return ruleBuilder
             .NotNull()
             .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
-            .MinimumLength(CourseConstraints.DescriptionMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
             .MaximumLength(CourseConstraints.DescriptionMaxLength)
             .WithErrorCode(ValidationErrorCodes.TooLong);
     }

--- a/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
@@ -10,14 +10,14 @@ public static class CourseValidationExtensions
     {
         return ruleBuilder
             .MustNotBeNullOrWhitespace()
-            .MustNotExceedLength(CourseConstraints.NameMaxLength);
+            .LengthMustNotExceed(CourseConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> CourseDescription<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
             .MustNotBeNull()
-            .MustNotExceedLength(CourseConstraints.DescriptionMaxLength);
+            .LengthMustNotExceed(CourseConstraints.DescriptionMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> CourseId<T>(this IRuleBuilder<T, int> ruleBuilder, ICourseService courseService)

--- a/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
@@ -9,19 +9,15 @@ public static class CourseValidationExtensions
     public static IRuleBuilderOptions<T, string?> CourseName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MaximumLength(CourseConstraints.NameMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullOrWhitespaceRule()
+            .MaxLengthRule(CourseConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> CourseDescription<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNull()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
-            .MaximumLength(CourseConstraints.DescriptionMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullRule()
+            .MaxLengthRule(CourseConstraints.DescriptionMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> CourseId<T>(this IRuleBuilder<T, int> ruleBuilder, ICourseService courseService)

--- a/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Course/CourseValidationExtensions.cs
@@ -9,15 +9,15 @@ public static class CourseValidationExtensions
     public static IRuleBuilderOptions<T, string?> CourseName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullOrWhitespaceRule()
-            .MaxLengthRule(CourseConstraints.NameMaxLength);
+            .MustNotBeNullOrWhitespace()
+            .MustNotExceedLength(CourseConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> CourseDescription<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullRule()
-            .MaxLengthRule(CourseConstraints.DescriptionMaxLength);
+            .MustNotBeNull()
+            .MustNotExceedLength(CourseConstraints.DescriptionMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> CourseId<T>(this IRuleBuilder<T, int> ruleBuilder, ICourseService courseService)

--- a/server/src/Application/Validation/Validators/Course/CreateCourseRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Course/CreateCourseRequestValidator.cs
@@ -7,15 +7,9 @@ public class CreateCourseRequestValidator : AbstractValidator<CreateCourseDto>
 {
     public CreateCourseRequestValidator()
     {
-        RuleFor(course => course.Name)
-            .NotEmpty()
-            .WithMessage("Name must not be empty!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
-        RuleFor(course => course.Description)
-            .NotNull()
-            .WithMessage("Description cannot be null!")
-            .MaximumLength(200)
-            .WithMessage("Content must not exceed 200 symbols!");
+        RuleFor(c => c.Name)
+            .CourseName();
+        RuleFor(c => c.Description)
+            .CourseDescription();
     }
 }

--- a/server/src/Application/Validation/Validators/Course/UpdateCourseRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Course/UpdateCourseRequestValidator.cs
@@ -8,15 +8,10 @@ public class UpdateCourseRequestValidator : AbstractValidator<UpdateCourseDto>
     public UpdateCourseRequestValidator()
     {
         RuleFor(c => c.Name)
-            .NotEmpty()
-            .Unless(c => c.Name is null)
-            .WithMessage("Name must not be empty or whitespace!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
+            .CourseName()
+            .Unless(c => c.Name is null);
         RuleFor(course => course.Description)
-            .NotEmpty()
-            .Unless(c => c.Description is null || c.Description.Equals(""))
-            .WithMessage("Description must not be whitespace!")
-            .MaximumLength(200).WithMessage("Description must not exceed 200 symbols!");
+            .CourseDescription()
+            .Unless(c => c.Description is null);
     }
 }

--- a/server/src/Application/Validation/Validators/Flashcard/CreateFlashcardRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/CreateFlashcardRequestValidator.cs
@@ -6,28 +6,13 @@ namespace StudyZen.Application.Validation;
 
 public class CreateFlashcardRequestValidator : AbstractValidator<CreateFlashcardDto>
 {
-    private readonly IFlashcardSetService _flashcardSetService;
-
     public CreateFlashcardRequestValidator(IFlashcardSetService flashcardSetService)
     {
-        _flashcardSetService = flashcardSetService;
-        RuleFor(flashcard => flashcard.Front)
-            .NotEmpty()
-            .WithMessage("Front must not be empty!")
-            .MaximumLength(50)
-            .WithMessage("Front must not exceed 50 symbols!");
-        RuleFor(flashcard => flashcard.Back)
-            .NotEmpty()
-            .WithMessage("Back cannot be null!")
-            .MaximumLength(50)
-            .WithMessage("Back must not exceed 50 symbols!");
-        RuleFor(flashcard => flashcard.FlashcardSetId)
-            .Must(IsValidFlashcardSetId)
-            .WithMessage("FlashcardSet with the given id does not exist!");
-    }
-
-    protected bool IsValidFlashcardSetId(int flashcardSetId)
-    {
-        return _flashcardSetService.GetFlashcardSetById(flashcardSetId) is not null;
+        RuleFor(f => f.Front)
+            .FlashcardFront();
+        RuleFor(f => f.Back)
+            .FlashcardBack();
+        RuleFor(f => f.FlashcardSetId)
+            .FlashcardSetId(flashcardSetService);
     }
 }

--- a/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
@@ -9,13 +9,13 @@ public static class FlashcardValidationExtensions
     {
         return ruleBuilder
             .MustNotBeNullOrWhitespace()
-            .MustNotExceedLength(FlashcardConstraints.FrontMaxLength);
+            .LengthMustNotExceed(FlashcardConstraints.FrontMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> FlashcardBack<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
             .MustNotBeNullOrWhitespace()
-            .MustNotExceedLength(FlashcardConstraints.BackMaxLength);
+            .LengthMustNotExceed(FlashcardConstraints.BackMaxLength);
     }
 }

--- a/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
@@ -1,0 +1,29 @@
+﻿using FluentValidation;
+using StudyZen.Domain.Constraints;
+
+namespace StudyZen.Application.Validation;
+
+public static class FlashcardValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> FlashcardFront<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
+            .MinimumLength(FlashcardConstraints.FrontMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(FlashcardConstraints.FrontMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, string?> FlashcardBack<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
+            .MinimumLength(FlashcardConstraints.BackMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(FlashcardConstraints.BackMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+}

--- a/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
@@ -8,22 +8,14 @@ public static class FlashcardValidationExtensions
     public static IRuleBuilderOptions<T, string?> FlashcardFront<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MinimumLength(FlashcardConstraints.FrontMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
-            .MaximumLength(FlashcardConstraints.FrontMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullOrWhitespaceRule()
+            .MaxLengthRule(FlashcardConstraints.FrontMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> FlashcardBack<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MinimumLength(FlashcardConstraints.BackMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
-            .MaximumLength(FlashcardConstraints.BackMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullOrWhitespaceRule()
+            .MaxLengthRule(FlashcardConstraints.BackMaxLength);
     }
 }

--- a/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/FlashcardValidationExtensions.cs
@@ -8,14 +8,14 @@ public static class FlashcardValidationExtensions
     public static IRuleBuilderOptions<T, string?> FlashcardFront<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullOrWhitespaceRule()
-            .MaxLengthRule(FlashcardConstraints.FrontMaxLength);
+            .MustNotBeNullOrWhitespace()
+            .MustNotExceedLength(FlashcardConstraints.FrontMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> FlashcardBack<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullOrWhitespaceRule()
-            .MaxLengthRule(FlashcardConstraints.BackMaxLength);
+            .MustNotBeNullOrWhitespace()
+            .MustNotExceedLength(FlashcardConstraints.BackMaxLength);
     }
 }

--- a/server/src/Application/Validation/Validators/Flashcard/UpdateFlashcardRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Flashcard/UpdateFlashcardRequestValidator.cs
@@ -8,17 +8,10 @@ public class UpdateFlashcardRequestValidator : AbstractValidator<UpdateFlashcard
     public UpdateFlashcardRequestValidator()
     {
         RuleFor(f => f.Front)
-            .NotEmpty()
-            .Unless(f => f.Front is null)
-            .WithMessage("Front must not be empty or whitespace!")
-            .WithMessage("Front must not be empty or whitespace!")
-            .MaximumLength(50)
-            .WithMessage("Front must not exceed 50 symbols!");
+            .FlashcardFront()
+            .Unless(f => f.Front is null);
         RuleFor(f => f.Back)
-            .NotEmpty()
-            .Unless(f => f.Back is null || f.Back.Equals(""))
-            .WithMessage("Back must not be whitespace!")
-            .MaximumLength(50)
-            .WithMessage("Back must not exceed 50 symbols!");
+            .FlashcardBack()
+            .Unless(f => f.Back is null);
     }
 }

--- a/server/src/Application/Validation/Validators/FlashcardSet/CreateFlashcardSetRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/CreateFlashcardSetRequestValidator.cs
@@ -6,23 +6,11 @@ namespace StudyZen.Application.Validation;
 
 public class CreateFlashcardSetRequestValidator : AbstractValidator<CreateFlashcardSetDto>
 {
-    private readonly ILectureService _lectureService;
-
     public CreateFlashcardSetRequestValidator(ILectureService lectureService)
     {
-        _lectureService = lectureService;
-        RuleFor(flashcardSet => flashcardSet.Name)
-            .NotEmpty()
-            .WithMessage("Name must not be empty!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
-        RuleFor(flashcardSet => flashcardSet.LectureId)
-            .Must(IsValidLectureId)
-            .WithMessage("Lecture with the given id does not exist!");
-    }
-
-    protected bool IsValidLectureId(int? lectureId)
-    {
-        return lectureId is null || _lectureService.GetLectureById(lectureId ?? 0) is not null;
+        RuleFor(fs => fs.Name)
+            .FlashcardSetName();
+        RuleFor(fs => fs.LectureId)
+            .OptionalLectureId(lectureService);
     }
 }

--- a/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
@@ -1,0 +1,26 @@
+﻿using FluentValidation;
+using StudyZen.Application.Services;
+using StudyZen.Domain.Constraints;
+
+namespace StudyZen.Application.Validation;
+
+public static class FlashcardSetValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> FlashcardSetName<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
+            .MinimumLength(FlashcardSetConstraints.NameMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(FlashcardSetConstraints.NameMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, int> FlashcardSetId<T>(this IRuleBuilder<T, int> ruleBuilder, IFlashcardSetService flashcardSetService)
+    {
+        return ruleBuilder
+            .Must(id => flashcardSetService.GetFlashcardSetById(id) is not null)
+            .WithErrorCode(ValidationErrorCodes.NotFound);
+    }
+}

--- a/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
@@ -9,10 +9,8 @@ public static class FlashcardSetValidationExtensions
     public static IRuleBuilderOptions<T, string?> FlashcardSetName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MaximumLength(FlashcardSetConstraints.NameMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullOrWhitespaceRule()
+            .MaxLengthRule(FlashcardSetConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> FlashcardSetId<T>(this IRuleBuilder<T, int> ruleBuilder, IFlashcardSetService flashcardSetService)

--- a/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
@@ -10,7 +10,7 @@ public static class FlashcardSetValidationExtensions
     {
         return ruleBuilder
             .MustNotBeNullOrWhitespace()
-            .MustNotExceedLength(FlashcardSetConstraints.NameMaxLength);
+            .LengthMustNotExceed(FlashcardSetConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> FlashcardSetId<T>(this IRuleBuilder<T, int> ruleBuilder, IFlashcardSetService flashcardSetService)

--- a/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
@@ -9,8 +9,8 @@ public static class FlashcardSetValidationExtensions
     public static IRuleBuilderOptions<T, string?> FlashcardSetName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullOrWhitespaceRule()
-            .MaxLengthRule(FlashcardSetConstraints.NameMaxLength);
+            .MustNotBeNullOrWhitespace()
+            .MustNotExceedLength(FlashcardSetConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int> FlashcardSetId<T>(this IRuleBuilder<T, int> ruleBuilder, IFlashcardSetService flashcardSetService)

--- a/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/FlashcardSetValidationExtensions.cs
@@ -11,8 +11,6 @@ public static class FlashcardSetValidationExtensions
         return ruleBuilder
             .NotEmpty()
             .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MinimumLength(FlashcardSetConstraints.NameMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
             .MaximumLength(FlashcardSetConstraints.NameMaxLength)
             .WithErrorCode(ValidationErrorCodes.TooLong);
     }

--- a/server/src/Application/Validation/Validators/FlashcardSet/UpdateFlashcardSetRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/FlashcardSet/UpdateFlashcardSetRequestValidator.cs
@@ -8,10 +8,7 @@ public class UpdateFlashcardSetRequestValidator : AbstractValidator<UpdateFlashc
     public UpdateFlashcardSetRequestValidator()
     {
         RuleFor(f => f.Name)
-            .NotEmpty()
-            .Unless(f => f.Name is null)
-            .WithMessage("Name must not be empty or whitespace!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
+            .FlashcardSetName()
+            .Unless(f => f.Name is null);
     }
 }

--- a/server/src/Application/Validation/Validators/Lecture/CreateLectureRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Lecture/CreateLectureRequestValidator.cs
@@ -6,28 +6,13 @@ namespace StudyZen.Application.Validation;
 
 public class CreateLectureRequestValidator : AbstractValidator<CreateLectureDto>
 {
-    private readonly ICourseService _courseService;
-
     public CreateLectureRequestValidator(ICourseService courseService)
     {
-        _courseService = courseService;
-        RuleFor(lecture => lecture.Name)
-            .NotEmpty()
-            .WithMessage("Name must not be empty!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
-        RuleFor(lecture => lecture.Content)
-            .NotNull()
-            .WithMessage("Content cannot be null!")
-            .MaximumLength(20000)
-            .WithMessage("Content must not exceed 20000 symbols!");
-        RuleFor(lecture => lecture.CourseId)
-            .Must(IsValidCourseId)
-            .WithMessage("Course with the given id does not exist!");
-    }
-
-    protected bool IsValidCourseId(int courseId)
-    {
-        return _courseService.GetCourseById(courseId) is not null;
+        RuleFor(l => l.Name)
+            .LectureName();
+        RuleFor(l => l.Content)
+            .LectureContent();
+        RuleFor(l => l.CourseId)
+            .CourseId(courseService);
     }
 }

--- a/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
@@ -9,19 +9,15 @@ public static class LectureValidationExtensions
     public static IRuleBuilderOptions<T, string?> LectureName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotEmpty()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MaximumLength(LectureConstraints.NameMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullOrWhitespaceRule()
+            .MaxLengthRule(LectureConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> LectureContent<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNull()
-            .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
-            .MaximumLength(LectureConstraints.ContentMaxLength)
-            .WithErrorCode(ValidationErrorCodes.TooLong);
+            .NotNullRule()
+            .MaxLengthRule(LectureConstraints.ContentMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int?> OptionalLectureId<T>(this IRuleBuilder<T, int?> ruleBuilder, ILectureService lectureService)

--- a/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
@@ -9,15 +9,15 @@ public static class LectureValidationExtensions
     public static IRuleBuilderOptions<T, string?> LectureName<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullOrWhitespaceRule()
-            .MaxLengthRule(LectureConstraints.NameMaxLength);
+            .MustNotBeNullOrWhitespace()
+            .MustNotExceedLength(LectureConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> LectureContent<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .NotNullRule()
-            .MaxLengthRule(LectureConstraints.ContentMaxLength);
+            .MustNotBeNull()
+            .MustNotExceedLength(LectureConstraints.ContentMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int?> OptionalLectureId<T>(this IRuleBuilder<T, int?> ruleBuilder, ILectureService lectureService)

--- a/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
@@ -11,8 +11,6 @@ public static class LectureValidationExtensions
         return ruleBuilder
             .NotEmpty()
             .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
-            .MinimumLength(LectureConstraints.NameMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
             .MaximumLength(LectureConstraints.NameMaxLength)
             .WithErrorCode(ValidationErrorCodes.TooLong);
     }
@@ -22,8 +20,6 @@ public static class LectureValidationExtensions
         return ruleBuilder
             .NotNull()
             .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
-            .MinimumLength(LectureConstraints.ContentMinLength)
-            .WithErrorCode(ValidationErrorCodes.TooShort)
             .MaximumLength(LectureConstraints.ContentMaxLength)
             .WithErrorCode(ValidationErrorCodes.TooLong);
     }

--- a/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
@@ -1,0 +1,37 @@
+﻿using FluentValidation;
+using StudyZen.Application.Services;
+using StudyZen.Domain.Constraints;
+
+namespace StudyZen.Application.Validation;
+
+public static class LectureValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> LectureName<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeEmpty)
+            .MinimumLength(LectureConstraints.NameMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(LectureConstraints.NameMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, string?> LectureContent<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotNull()
+            .WithErrorCode(ValidationErrorCodes.MustNotBeNull)
+            .MinimumLength(LectureConstraints.ContentMinLength)
+            .WithErrorCode(ValidationErrorCodes.TooShort)
+            .MaximumLength(LectureConstraints.ContentMaxLength)
+            .WithErrorCode(ValidationErrorCodes.TooLong);
+    }
+
+    public static IRuleBuilderOptions<T, int?> OptionalLectureId<T>(this IRuleBuilder<T, int?> ruleBuilder, ILectureService lectureService)
+    {
+        return ruleBuilder
+            .Must(id => !id.HasValue || lectureService.GetLectureById(id.Value) is not null)
+            .WithErrorCode(ValidationErrorCodes.NotFound);
+    }
+}

--- a/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/Lecture/LectureValidationExtensions.cs
@@ -10,14 +10,14 @@ public static class LectureValidationExtensions
     {
         return ruleBuilder
             .MustNotBeNullOrWhitespace()
-            .MustNotExceedLength(LectureConstraints.NameMaxLength);
+            .LengthMustNotExceed(LectureConstraints.NameMaxLength);
     }
 
     public static IRuleBuilderOptions<T, string?> LectureContent<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
             .MustNotBeNull()
-            .MustNotExceedLength(LectureConstraints.ContentMaxLength);
+            .LengthMustNotExceed(LectureConstraints.ContentMaxLength);
     }
 
     public static IRuleBuilderOptions<T, int?> OptionalLectureId<T>(this IRuleBuilder<T, int?> ruleBuilder, ILectureService lectureService)

--- a/server/src/Application/Validation/Validators/Lecture/UpdateLectureRequestValidator.cs
+++ b/server/src/Application/Validation/Validators/Lecture/UpdateLectureRequestValidator.cs
@@ -8,15 +8,10 @@ public sealed class UpdateLectureRequestValidator : AbstractValidator<UpdateLect
     public UpdateLectureRequestValidator()
     {
         RuleFor(l => l.Name)
-            .NotEmpty()
-            .Unless(l => l.Name is null)
-            .WithMessage("Name must not be empty or whitespace!")
-            .MaximumLength(50)
-            .WithMessage("Name must not exceed 50 symbols!");
+            .LectureName()
+            .Unless(l => l.Name is null);
         RuleFor(lecture => lecture.Content)
-            .NotEmpty()
-            .Unless(l => l.Content is null || l.Content.Equals(""))
-            .WithMessage("Name must not be whitespace!")
-            .MaximumLength(20000).WithMessage("Content must not exceed 20000 symbols!");
+            .LectureContent()
+            .Unless(l => l.Content is null);
     }
 }

--- a/server/src/Application/Validation/Validators/ValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/ValidationExtensions.cs
@@ -5,7 +5,7 @@ namespace StudyZen.Application.Validation;
 // might be a useful reference for future: https://github.com/FluentValidation/FluentValidation/issues/1688
 public static class ValidationExtensions
 {
-    public static IRuleBuilderOptions<T, string?> MustNotBeNull<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    public static IRuleBuilderOptions<T, TProperty?> MustNotBeNull<T, TProperty>(this IRuleBuilder<T, TProperty?> ruleBuilder)
     {
         return ruleBuilder
             .NotNull()
@@ -19,7 +19,7 @@ public static class ValidationExtensions
             .WithErrorCode(ValidationErrorCodes.NullOrWhitespace);
     }
 
-    public static IRuleBuilderOptions<T, string?> MustNotExceedLength<T>(this IRuleBuilder<T, string?> ruleBuilder, int maxLength)
+    public static IRuleBuilderOptions<T, string?> LengthMustNotExceed<T>(this IRuleBuilder<T, string?> ruleBuilder, int maxLength)
     {
         return ruleBuilder
             .MaximumLength(maxLength)

--- a/server/src/Application/Validation/Validators/ValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/ValidationExtensions.cs
@@ -1,0 +1,28 @@
+﻿using FluentValidation;
+
+namespace StudyZen.Application.Validation;
+
+// might be a useful reference for future: https://github.com/FluentValidation/FluentValidation/issues/1688
+public static class ValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> NotNullRule<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotNull()
+            .WithErrorCode(ValidationErrorCodes.Null);
+    }
+
+    public static IRuleBuilderOptions<T, string?> NotNullOrWhitespaceRule<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .NotEmpty()
+            .WithErrorCode(ValidationErrorCodes.NullOrWhitespace);
+    }
+
+    public static IRuleBuilderOptions<T, string?> MaxLengthRule<T>(this IRuleBuilder<T, string?> ruleBuilder, int maxLength)
+    {
+        return ruleBuilder
+            .MaximumLength(maxLength)
+            .WithErrorCode(ValidationErrorCodes.MaxLength);
+    }
+}

--- a/server/src/Application/Validation/Validators/ValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/ValidationExtensions.cs
@@ -5,21 +5,21 @@ namespace StudyZen.Application.Validation;
 // might be a useful reference for future: https://github.com/FluentValidation/FluentValidation/issues/1688
 public static class ValidationExtensions
 {
-    public static IRuleBuilderOptions<T, string?> NotNullRule<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> MustNotBeNull<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
             .NotNull()
             .WithErrorCode(ValidationErrorCodes.Null);
     }
 
-    public static IRuleBuilderOptions<T, string?> NotNullOrWhitespaceRule<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    public static IRuleBuilderOptions<T, string?> MustNotBeNullOrWhitespace<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
             .NotEmpty()
             .WithErrorCode(ValidationErrorCodes.NullOrWhitespace);
     }
 
-    public static IRuleBuilderOptions<T, string?> MaxLengthRule<T>(this IRuleBuilder<T, string?> ruleBuilder, int maxLength)
+    public static IRuleBuilderOptions<T, string?> MustNotExceedLength<T>(this IRuleBuilder<T, string?> ruleBuilder, int maxLength)
     {
         return ruleBuilder
             .MaximumLength(maxLength)

--- a/server/src/Domain/Constraints/CourseConstraints.cs
+++ b/server/src/Domain/Constraints/CourseConstraints.cs
@@ -2,8 +2,6 @@
 
 public static class CourseConstraints
 {
-    public const int NameMinLength = 1;
     public const int NameMaxLength = 200;
-    public const int DescriptionMinLength = 0;
     public const int DescriptionMaxLength = 2000;
 }

--- a/server/src/Domain/Constraints/CourseConstraints.cs
+++ b/server/src/Domain/Constraints/CourseConstraints.cs
@@ -1,0 +1,9 @@
+﻿namespace StudyZen.Domain.Constraints;
+
+public static class CourseConstraints
+{
+    public const int NameMinLength = 1;
+    public const int NameMaxLength = 200;
+    public const int DescriptionMinLength = 0;
+    public const int DescriptionMaxLength = 2000;
+}

--- a/server/src/Domain/Constraints/FlashcardConstraints.cs
+++ b/server/src/Domain/Constraints/FlashcardConstraints.cs
@@ -1,0 +1,9 @@
+﻿namespace StudyZen.Domain.Constraints;
+
+public static class FlashcardConstraints
+{
+    public const int FrontMinLength = 1;
+    public const int FrontMaxLength = 300;
+    public const int BackMinLength = 1;
+    public const int BackMaxLength = 300;
+}

--- a/server/src/Domain/Constraints/FlashcardConstraints.cs
+++ b/server/src/Domain/Constraints/FlashcardConstraints.cs
@@ -2,8 +2,6 @@
 
 public static class FlashcardConstraints
 {
-    public const int FrontMinLength = 1;
     public const int FrontMaxLength = 300;
-    public const int BackMinLength = 1;
     public const int BackMaxLength = 300;
 }

--- a/server/src/Domain/Constraints/FlashcardSetConstraints.cs
+++ b/server/src/Domain/Constraints/FlashcardSetConstraints.cs
@@ -2,6 +2,5 @@
 
 public static class FlashcardSetConstraints
 {
-    public const int NameMinLength = 1;
     public const int NameMaxLength = 200;
 }

--- a/server/src/Domain/Constraints/FlashcardSetConstraints.cs
+++ b/server/src/Domain/Constraints/FlashcardSetConstraints.cs
@@ -1,0 +1,7 @@
+﻿namespace StudyZen.Domain.Constraints;
+
+public static class FlashcardSetConstraints
+{
+    public const int NameMinLength = 1;
+    public const int NameMaxLength = 200;
+}

--- a/server/src/Domain/Constraints/LectureConstraints.cs
+++ b/server/src/Domain/Constraints/LectureConstraints.cs
@@ -1,0 +1,9 @@
+﻿namespace StudyZen.Domain.Constraints;
+
+public static class LectureConstraints
+{
+    public const int NameMinLength = 1;
+    public const int NameMaxLength = 200;
+    public const int ContentMinLength = 0;
+    public const int ContentMaxLength = 10000;
+}

--- a/server/src/Domain/Constraints/LectureConstraints.cs
+++ b/server/src/Domain/Constraints/LectureConstraints.cs
@@ -2,8 +2,6 @@
 
 public static class LectureConstraints
 {
-    public const int NameMinLength = 1;
     public const int NameMaxLength = 200;
-    public const int ContentMinLength = 0;
     public const int ContentMaxLength = 10000;
 }


### PR DESCRIPTION
- Added static classes in Domain, which store constants of entity constraints. This will let us to reuse the constraints for validation and when mapping entities to DB.
- Added some extension methods for reusing validation logic across create and update request validators.
- Added error codes for validation errors. Error codes allow for error message localization in the front-end, rather than the back-end. Will make a PR in the future for mapping these values more elegantly in the response so that they could be used in the front-end.
- Fixed reference in DependencyInjection for ValidationError. The ValidationError was from the wrong assembly so it returned 500 rather than 422.
- Suppressed default validation, which sometimes took precedence to FluentValidation