### PR TITLE
Bug hotfix

### DIFF
--- a/server/src/Application/Services/Flashcard/FlashcardService.cs
+++ b/server/src/Application/Services/Flashcard/FlashcardService.cs
@@ -28,8 +28,14 @@ public sealed class FlashcardService : IFlashcardService
 
     public async Task<IReadOnlyCollection<FlashcardDto>> CreateFlashcards(IEnumerable<CreateFlashcardDto> dtos)
     {
-        var tasks = dtos.Select(dto => CreateFlashcard(dto));
-        var results = await Task.WhenAll(tasks);
+        var results = new List<FlashcardDto>();
+
+        foreach (var dto in dtos)
+        {
+            var result = await CreateFlashcard(dto);
+            results.Add(result);
+        }
+
         return results;
     }
 

--- a/server/src/Application/Validation/Validators/FileMetadata/FileMetadataValidationExtensions.cs
+++ b/server/src/Application/Validation/Validators/FileMetadata/FileMetadataValidationExtensions.cs
@@ -20,12 +20,7 @@ public static class FileMetadataValidationExtensions
             .NotEmpty()
             .Must(IsCsvFile).WithMessage("Only CSV files are allowed");
     }
-    public static IRuleBuilderOptions<T, string?> FileType<T>(this IRuleBuilder<T, string?> ruleBuilder)
-    {
-        return ruleBuilder
-            .Equal("text/csv")
-            .WithMessage("mime type must be text/csv"); ;
-    }
+
     static bool IsCsvFile(string? fileName)
     {
         return string.IsNullOrWhiteSpace(fileName) ? false : Regex.IsMatch(fileName, @"\.csv$", RegexOptions.IgnoreCase);

--- a/server/src/Application/Validation/Validators/FileMetadata/FileMetadataValidator.cs
+++ b/server/src/Application/Validation/Validators/FileMetadata/FileMetadataValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using StudyZen.Application.Validation;
+using StudyZen.Application.ValueObjects;
 
 public class FileMetadataValidator : AbstractValidator<FileMetadata>
 {
@@ -9,7 +10,5 @@ public class FileMetadataValidator : AbstractValidator<FileMetadata>
             .FileSize();
         RuleFor(f => f.FileName)
             .FileName();
-        RuleFor(f => f.FileType)
-            .FileType();
     }
 }

--- a/server/src/Domain/Entities/FlashcardSet.cs
+++ b/server/src/Domain/Entities/FlashcardSet.cs
@@ -10,7 +10,7 @@ public sealed class FlashcardSet : BaseEntity
     public int? LectureId { get; set; }
 
     [ForeignKey(nameof(LectureId))]
-    public Lecture Lecture { get; set; } = null!;
+    public Lecture? Lecture { get; set; } = null;
 
     [Required]
     [StringLength(FlashcardSetConstraints.NameMaxLength)]

--- a/server/src/Infrastructure/Migrations/20231017140953_UpdateLectureSchema.Designer.cs
+++ b/server/src/Infrastructure/Migrations/20231017140953_UpdateLectureSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using StudyZen.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using StudyZen.Infrastructure.Persistence;
 namespace StudyZen.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231017140953_UpdateLectureSchema")]
+    partial class UpdateLectureSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/Infrastructure/Migrations/20231017140953_UpdateLectureSchema.cs
+++ b/server/src/Infrastructure/Migrations/20231017140953_UpdateLectureSchema.cs
@@ -1,0 +1,139 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StudyZen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class UpdateLectureSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FlashcardSets_Lectures_LectureId",
+                table: "FlashcardSets");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_TimeStamp",
+                table: "Lectures",
+                newName: "UpdatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_TimeStamp",
+                table: "Lectures",
+                newName: "CreatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_TimeStamp",
+                table: "FlashcardSets",
+                newName: "UpdatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_TimeStamp",
+                table: "FlashcardSets",
+                newName: "CreatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_TimeStamp",
+                table: "Flashcards",
+                newName: "UpdatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_TimeStamp",
+                table: "Flashcards",
+                newName: "CreatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_TimeStamp",
+                table: "Courses",
+                newName: "UpdatedBy_Timestamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_TimeStamp",
+                table: "Courses",
+                newName: "CreatedBy_Timestamp");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "LectureId",
+                table: "FlashcardSets",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FlashcardSets_Lectures_LectureId",
+                table: "FlashcardSets",
+                column: "LectureId",
+                principalTable: "Lectures",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FlashcardSets_Lectures_LectureId",
+                table: "FlashcardSets");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_Timestamp",
+                table: "Lectures",
+                newName: "UpdatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_Timestamp",
+                table: "Lectures",
+                newName: "CreatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_Timestamp",
+                table: "FlashcardSets",
+                newName: "UpdatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_Timestamp",
+                table: "FlashcardSets",
+                newName: "CreatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_Timestamp",
+                table: "Flashcards",
+                newName: "UpdatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_Timestamp",
+                table: "Flashcards",
+                newName: "CreatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "UpdatedBy_Timestamp",
+                table: "Courses",
+                newName: "UpdatedBy_TimeStamp");
+
+            migrationBuilder.RenameColumn(
+                name: "CreatedBy_Timestamp",
+                table: "Courses",
+                newName: "CreatedBy_TimeStamp");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "LectureId",
+                table: "FlashcardSets",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FlashcardSets_Lectures_LectureId",
+                table: "FlashcardSets",
+                column: "LectureId",
+                principalTable: "Lectures",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}


### PR DESCRIPTION
` var tasks = dtos.Select(dto => CreateFlashcard(dto));
        var results = await Task.WhenAll(tasks);
        return results;`
this part was causing errors, because CreateFlashcard for each dto tried to concurrently access the db_context, fixed it.
Also removed file mime type validation for "texr/csv", because the type is " multipart/form-data", so it also caused fake validation errors.
Also fixed the lecture fk being non nullable