### PR TITLE
Add default connection string

### DIFF
--- a/server/src/Api/appsettings.Development.json
+++ b/server/src/Api/appsettings.Development.json
@@ -16,5 +16,8 @@
         }
       }
     ]
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=localhost; Database=studyzen_db; Trusted_Connection=True; MultipleActiveResultSets=True; TrustServerCertificate=True;"
   }
 }

--- a/server/src/Api/appsettings.Development.json
+++ b/server/src/Api/appsettings.Development.json
@@ -18,6 +18,6 @@
     ]
   },
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost; Database=studyzen_db; Trusted_Connection=True; MultipleActiveResultSets=True; TrustServerCertificate=True;"
+    "DefaultConnection": "Server=localhost; Database=studyzen_db; Trusted_Connection=True; TrustServerCertificate=True;"
   }
 }

--- a/server/src/Domain/Domain.csproj
+++ b/server/src/Domain/Domain.csproj
@@ -6,4 +6,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.12" />
+  </ItemGroup>
 </Project>

--- a/server/src/Domain/Domain.csproj
+++ b/server/src/Domain/Domain.csproj
@@ -6,7 +6,4 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.12" />
-  </ItemGroup>
 </Project>

--- a/server/src/Infrastructure/Infrastructure.csproj
+++ b/server/src/Infrastructure/Infrastructure.csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.12">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
- Added default connection string for development
- Removed EF Core dependency in Infrastructure project since it is unnecessary - we added it to Domain :(
- Run `dotnet ef database update -p src/Api` to create the database