### PR TITLE
thread usage instead of  Parallel.ForEach

### DIFF
--- a/server/src/Application/Services/FlashcardImporter/FlashcardImporter.cs
+++ b/server/src/Application/Services/FlashcardImporter/FlashcardImporter.cs
@@ -22,10 +22,7 @@ public sealed class FlashcardImporter : IFlashcardImporter
 
         var lines = stream.ReadLines();
         var importedFlashcards = new BlockingCollection<CreateFlashcardDto>();
-
-        int batchSize = 10; 
-        var batches = PartitionBatch(lines, batchSize);
-
+        var batches = PartitionBatch(lines, 3); 
         var threadList = new List<Thread>();
 
         foreach (var batch in batches)
@@ -62,16 +59,22 @@ public sealed class FlashcardImporter : IFlashcardImporter
         return importedFlashcards.GetConsumingEnumerable().ToList();
     }
 
-    private IEnumerable<IEnumerable<string>> PartitionBatch(IEnumerable<string> source, int batchSize)
+    private IEnumerable<IEnumerable<string>> PartitionBatch(IEnumerable<string> source, int numberOfBatches)
     {
         var batch = new List<string>();
+        int batchSize = source.Count() / numberOfBatches;
+        int currentBatchSize = 0;
+
         foreach (var item in source)
         {
             batch.Add(item);
-            if (batch.Count == batchSize)
+            currentBatchSize++;
+
+            if (currentBatchSize >= batchSize)
             {
                 yield return batch;
                 batch = new List<string>();
+                currentBatchSize = 0;
             }
         }
 

--- a/server/src/Application/Services/FlashcardImporter/FlashcardImporter.cs
+++ b/server/src/Application/Services/FlashcardImporter/FlashcardImporter.cs
@@ -78,26 +78,14 @@ public sealed class FlashcardImporter : IFlashcardImporter
 
     private IEnumerable<IEnumerable<string>> PartitionBatch(IEnumerable<string> source, int numberOfBatches)
     {
-        var batch = new List<string>();
+       
         int batchSize = source.Count() / numberOfBatches;
-        int currentBatchSize = 0;
+        int skipCount = 0;
 
-        foreach (var item in source)
+        while (skipCount < source.Count())
         {
-            batch.Add(item);
-            currentBatchSize++;
-
-            if (currentBatchSize >= batchSize)
-            {
-                yield return batch;
-                batch = new List<string>();
-                currentBatchSize = 0;
-            }
-        }
-
-        if (batch.Count > 0)
-        {
-            yield return batch;
-        }
+            yield return source.Skip(skipCount).Take(batchSize);
+            skipCount += batchSize;
+        }     
     }
 }


### PR DESCRIPTION
Right now is used threading via Thread class (to implement the requirement) instead of Parallel.ForEach

 var flashcardsFromFile = await _flashcardImporter.ImportFlashcardsFromCsv(stream, flashcardSetId, fileMetadata); returns correct flashcards collection 

BUT here is A PROBLEM : right now something wrong with second step in importing flashcards: I have checked with debugger , here var createdFlashcards = await _flashcardService.CreateFlashcards(flashcardsFromFile); the createdFlashcards returns null, but I haven't changed anything instead of ImportFlashcardsFromCsv method. Please, have a look  