### PR TITLE
Add initial quiz implementation

### DIFF
--- a/server/StudyZen.sln
+++ b/server/StudyZen.sln
@@ -11,13 +11,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure", "src\Infra
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Application", "src\Application\Application.csproj", "{416104DF-E1D1-44BE-8728-1920D355D34C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Api.UnitTests", "tests\Api.UnitTests\Api.UnitTests.csproj", "{35056845-6A7F-44F5-B4A6-24B224D468DB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Api.UnitTests", "tests\Api.UnitTests\Api.UnitTests.csproj", "{35056845-6A7F-44F5-B4A6-24B224D468DB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Application.UnitTests", "tests\Application.UnitTests\Application.UnitTests.csproj", "{7288682F-64D3-47D0-8CBB-F1A0F31D7D43}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Application.UnitTests", "tests\Application.UnitTests\Application.UnitTests.csproj", "{7288682F-64D3-47D0-8CBB-F1A0F31D7D43}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Infrastructure.UnitTests", "tests\Infrastructure.UnitTests\Infrastructure.UnitTests.csproj", "{B67D1CB5-2C31-4352-9A1E-9C14152C2BC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure.UnitTests", "tests\Infrastructure.UnitTests\Infrastructure.UnitTests.csproj", "{B67D1CB5-2C31-4352-9A1E-9C14152C2BC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Domain.UnitTests", "tests\Domain.UnitTests\Domain.UnitTests.csproj", "{89C72F08-083C-4B4F-BB67-34544052F86B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Domain.UnitTests", "tests\Domain.UnitTests\Domain.UnitTests.csproj", "{89C72F08-083C-4B4F-BB67-34544052F86B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{747227D3-F597-44FD-9F01-C7DA3F3F318B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{EA835602-2990-4643-AA8D-C36F7FE0B7EE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -60,6 +64,16 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{EA17CBC5-60E8-4A61-B676-8C1C0FD39640} = {747227D3-F597-44FD-9F01-C7DA3F3F318B}
+		{EAF524A9-A143-405B-8D2F-A57E3E541F1F} = {747227D3-F597-44FD-9F01-C7DA3F3F318B}
+		{25131029-B98C-449E-87FF-BD606429F30B} = {747227D3-F597-44FD-9F01-C7DA3F3F318B}
+		{416104DF-E1D1-44BE-8728-1920D355D34C} = {747227D3-F597-44FD-9F01-C7DA3F3F318B}
+		{35056845-6A7F-44F5-B4A6-24B224D468DB} = {EA835602-2990-4643-AA8D-C36F7FE0B7EE}
+		{7288682F-64D3-47D0-8CBB-F1A0F31D7D43} = {EA835602-2990-4643-AA8D-C36F7FE0B7EE}
+		{B67D1CB5-2C31-4352-9A1E-9C14152C2BC2} = {EA835602-2990-4643-AA8D-C36F7FE0B7EE}
+		{89C72F08-083C-4B4F-BB67-34544052F86B} = {EA835602-2990-4643-AA8D-C36F7FE0B7EE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7FF5ED68-7371-4B36-A0CB-4E22CA1F0A55}

--- a/server/src/Api/Controllers/QuizzesController.cs
+++ b/server/src/Api/Controllers/QuizzesController.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using StudyZen.Api.Extensions;
+using StudyZen.Application.Dtos;
+using StudyZen.Application.Services;
+
+namespace StudyZen.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public sealed class QuizzesController : ControllerBase
+{
+    private readonly IQuizService _quizService;
+
+    public QuizzesController(IQuizService quizService)
+    {
+        _quizService = quizService;
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> CreateQuiz(CreateQuizDto dto)
+    {
+        dto.ThrowIfRequestArgumentNull(nameof(dto));
+        var quiz = await _quizService.CreateQuiz(dto);
+        return CreatedAtAction(nameof(GetQuiz), new { quizId = quiz.Id }, quiz);
+    }
+
+    [HttpGet]
+    [Route("{quizId}")]
+    public async Task<IActionResult> GetQuiz(int quizId)
+    {
+        var quiz = await _quizService.GetQuiz(quizId);
+        return Ok(quiz);
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAllQuizzes()
+    {
+        var quizzes = await _quizService.GetAllQuizzes();
+        return Ok(quizzes);
+    }
+
+    [HttpPatch]
+    [Route("{quizId}")]
+    public async Task<IActionResult> UpdateQuiz(int quizId, UpdateQuizDto dto)
+    {
+        dto.ThrowIfRequestArgumentNull(nameof(dto));
+        await _quizService.UpdateQuiz(quizId, dto);
+        return Ok();
+    }
+
+    [HttpDelete]
+    [Route("{quizId}")]
+    public async Task<IActionResult> DeleteQuiz(int quizId)
+    {
+        await _quizService.DeleteQuiz(quizId);
+        return Ok();
+    }
+
+    [HttpPost]
+    [Route("{quizId}/Questions")]
+    public async Task<IActionResult> AddQuestionToQuiz(int quizId, CreateQuizQuestionDto dto)
+    {
+        dto.ThrowIfRequestArgumentNull(nameof(dto));
+        var question = await _quizService.AddQuestionToQuiz(quizId, dto);
+        return Ok(question);
+    }
+
+    [HttpGet]
+    [Route("{quizId}/Questions")]
+    public async Task<IActionResult> GetQuizQuestions(int quizId)
+    {
+        var questions = await _quizService.GetQuizQuestions(quizId);
+        return Ok(questions);
+    }
+}

--- a/server/src/Application/Application.csproj.DotSettings
+++ b/server/src/Application/Application.csproj.DotSettings
@@ -4,17 +4,24 @@
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cflashcard/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cflashcardset/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Clecture/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cquiz/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cquizanswer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cquizitem/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Cincoming_005Cquizquestion/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Coutgoing/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=dtos_005Coutgoing_005Ccourse/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Ccourse/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cdataimporter/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cflashcard/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cflashcardimporter/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cflashcardset/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Clecture/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquiz/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquizanswer/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquizanswerservice/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquizgame/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquizitemservice/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=services_005Cquizquestionservice/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators_005Ccourse/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators_005Cfilemetadata/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators_005Cflashcard/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators_005Cflashcardset/@EntryIndexedValue">True</s:Boolean>
     <s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=validation_005Cvalidators_005Clecture/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/server/src/Application/DependencyInjection.cs
+++ b/server/src/Application/DependencyInjection.cs
@@ -13,6 +13,7 @@ public static class DependencyInjection
         services.AddScoped<ILectureService, LectureService>();
         services.AddScoped<IFlashcardService, FlashcardService>();
         services.AddScoped<IFlashcardSetService, FlashcardSetService>();
+        services.AddScoped<IQuizService, QuizService>();
         services.AddScoped<IDataImporter, CsvDataImporter>();
         services.AddScoped<IFlashcardImporter, FlashcardImporter>();
         services.AddScoped<ValidationHandler>();

--- a/server/src/Application/Dtos/Incoming/Quiz/CreateQuizDto.cs
+++ b/server/src/Application/Dtos/Incoming/Quiz/CreateQuizDto.cs
@@ -1,0 +1,3 @@
+﻿namespace StudyZen.Application.Dtos;
+
+public sealed record CreateQuizDto(string Title);

--- a/server/src/Application/Dtos/Incoming/Quiz/CreateQuizQuestionDto.cs
+++ b/server/src/Application/Dtos/Incoming/Quiz/CreateQuizQuestionDto.cs
@@ -1,0 +1,7 @@
+﻿namespace StudyZen.Application.Dtos;
+
+public sealed record CreateQuizQuestionDto(
+    string Question,
+    string CorrectAnswer,
+    IEnumerable<string> IncorrectAnswers,
+    int TimeLimitInSeconds);

--- a/server/src/Application/Dtos/Incoming/Quiz/UpdateQuizDto.cs
+++ b/server/src/Application/Dtos/Incoming/Quiz/UpdateQuizDto.cs
@@ -1,0 +1,3 @@
+﻿namespace StudyZen.Application.Dtos;
+
+public sealed record UpdateQuizDto(string? Title);

--- a/server/src/Application/Dtos/Outgoing/QuizAnswerDto.cs
+++ b/server/src/Application/Dtos/Outgoing/QuizAnswerDto.cs
@@ -1,0 +1,15 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Dtos;
+
+public sealed record QuizAnswerDto
+{
+    public int Id { get; init; }
+    public string Answer { get; init; }
+
+    public QuizAnswerDto(QuizAnswer answer)
+    {
+        Id = answer.Id;
+        Answer = answer.Answer;
+    }
+}

--- a/server/src/Application/Dtos/Outgoing/QuizDto.cs
+++ b/server/src/Application/Dtos/Outgoing/QuizDto.cs
@@ -1,0 +1,15 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Dtos;
+
+public sealed record QuizDto
+{
+    public int Id { get; init; }
+    public string Title { get; init; }
+
+    public QuizDto(Quiz quiz)
+    {
+        Id = quiz.Id;
+        Title = quiz.Title;
+    }
+}

--- a/server/src/Application/Dtos/Outgoing/QuizQuestionDto.cs
+++ b/server/src/Application/Dtos/Outgoing/QuizQuestionDto.cs
@@ -1,0 +1,21 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Dtos;
+
+public sealed record QuizQuestionDto
+{
+    public int Id { get; init; }
+    public string Question { get; init; }
+    public List<QuizAnswerDto> PossibleAnswers { get; init; }
+    public int? CorrectAnswerId { get; init; }
+    public int TimeLimitInSeconds { get; init; }
+
+    public QuizQuestionDto(QuizQuestion quizQuestion)
+    {
+        Id = quizQuestion.Id;
+        Question = quizQuestion.Question;
+        PossibleAnswers = quizQuestion.PossibleAnswers.Select(i => new QuizAnswerDto(i)).ToList();
+        CorrectAnswerId = quizQuestion.CorrectAnswerId;
+        TimeLimitInSeconds = quizQuestion.TimeLimit.Seconds;
+    }
+}

--- a/server/src/Application/Repositories/IQuizAnswerRepository.cs
+++ b/server/src/Application/Repositories/IQuizAnswerRepository.cs
@@ -1,0 +1,7 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Repositories;
+
+public interface IQuizAnswerRepository : IRepository<QuizAnswer>
+{
+}

--- a/server/src/Application/Repositories/IQuizQuestionRepository.cs
+++ b/server/src/Application/Repositories/IQuizQuestionRepository.cs
@@ -1,0 +1,7 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Repositories;
+
+public interface IQuizQuestionRepository : IRepository<QuizQuestion>
+{
+}

--- a/server/src/Application/Repositories/IQuizRepository.cs
+++ b/server/src/Application/Repositories/IQuizRepository.cs
@@ -1,0 +1,7 @@
+﻿using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Repositories;
+
+public interface IQuizRepository : IRepository<Quiz>
+{
+}

--- a/server/src/Application/Repositories/IUnitOfWork.cs
+++ b/server/src/Application/Repositories/IUnitOfWork.cs
@@ -1,4 +1,6 @@
-﻿namespace StudyZen.Application.Repositories;
+﻿using Microsoft.EntityFrameworkCore.Storage;
+
+namespace StudyZen.Application.Repositories;
 
 public interface IUnitOfWork : IDisposable
 {
@@ -6,5 +8,9 @@ public interface IUnitOfWork : IDisposable
     ILectureRepository Lectures { get; }
     IFlashcardSetRepository FlashcardSets { get; }
     IFlashcardRepository Flashcards { get; }
+    IQuizRepository Quizzes { get; }
+    IQuizQuestionRepository QuizQuestions { get; }
+    IQuizAnswerRepository QuizAnswers { get; }
     Task<int> SaveChanges();
+    IDbContextTransaction BeginTransaction();
 }

--- a/server/src/Application/Services/Quiz/IQuizService.cs
+++ b/server/src/Application/Services/Quiz/IQuizService.cs
@@ -1,0 +1,14 @@
+﻿using StudyZen.Application.Dtos;
+
+namespace StudyZen.Application.Services;
+
+public interface IQuizService
+{
+    Task<QuizDto> CreateQuiz(CreateQuizDto dto);
+    Task<QuizDto> GetQuiz(int quizId);
+    Task<IReadOnlyCollection<QuizDto>> GetAllQuizzes();
+    Task UpdateQuiz(int quizId, UpdateQuizDto dto);
+    Task DeleteQuiz(int quizId);
+    Task<QuizQuestionDto> AddQuestionToQuiz(int quizId, CreateQuizQuestionDto dto);
+    Task<IReadOnlyCollection<QuizQuestionDto>> GetQuizQuestions(int quizId);
+}

--- a/server/src/Application/Services/Quiz/QuizService.cs
+++ b/server/src/Application/Services/Quiz/QuizService.cs
@@ -1,0 +1,102 @@
+﻿using StudyZen.Application.Dtos;
+using StudyZen.Application.Repositories;
+using StudyZen.Domain.Entities;
+
+namespace StudyZen.Application.Services;
+
+public sealed class QuizService : IQuizService
+{
+    private readonly IUnitOfWork _unitOfWork;
+
+    public QuizService(IUnitOfWork unitOfWork)
+    {
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<QuizDto> CreateQuiz(CreateQuizDto dto)
+    {
+        // TODO: add validation
+
+        var quiz = new Quiz(dto.Title);
+
+        _unitOfWork.Quizzes.Add(quiz);
+        await _unitOfWork.SaveChanges();
+
+        return new QuizDto(quiz);
+    }
+
+    public async Task<QuizDto> GetQuiz(int quizId)
+    {
+        var quiz = await _unitOfWork.Quizzes.GetByIdChecked(quizId);
+        return new QuizDto(quiz);
+    }
+
+    public async Task<IReadOnlyCollection<QuizDto>> GetAllQuizzes()
+    {
+        var quizzes = await _unitOfWork.Quizzes.Get();
+        return quizzes.Select(q => new QuizDto(q)).ToList();
+    }
+
+    public async Task UpdateQuiz(int quizId, UpdateQuizDto dto)
+    {
+        // TODO: add validation
+
+        var quiz = await _unitOfWork.Quizzes.GetByIdChecked(quizId);
+
+        quiz.Title = dto.Title ?? quiz.Title;
+
+        await _unitOfWork.SaveChanges();
+    }
+
+    public async Task DeleteQuiz(int quizId)
+    {
+        await _unitOfWork.Quizzes.DeleteByIdChecked(quizId);
+        await _unitOfWork.SaveChanges();
+    }
+
+    public async Task<QuizQuestionDto> AddQuestionToQuiz(int quizId, CreateQuizQuestionDto dto)
+    {
+        // TODO: add validation
+
+        var quiz = await _unitOfWork.Quizzes.GetByIdChecked(quizId);
+
+        // Starting a new transaction to avoid circular reference between question and correct answer when saving
+        await using var transaction = _unitOfWork.BeginTransaction();
+
+        try
+        {
+            var question = new QuizQuestion(quizId, dto.Question, TimeSpan.FromSeconds(dto.TimeLimitInSeconds));
+
+            var correctAnswer = new QuizAnswer(quizId, dto.CorrectAnswer);
+            question.PossibleAnswers.Add(correctAnswer);
+
+            foreach (var incorrectAnswer in dto.IncorrectAnswers)
+            {
+                var answer = new QuizAnswer(quizId, incorrectAnswer);
+                question.PossibleAnswers.Add(answer);
+            }
+
+            quiz.Questions.Add(question);
+            await _unitOfWork.SaveChanges();
+
+            question.CorrectAnswer = correctAnswer;
+            await _unitOfWork.SaveChanges();
+
+            await transaction.CommitAsync();
+
+            return new QuizQuestionDto(question);
+        }
+        catch
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyCollection<QuizQuestionDto>> GetQuizQuestions(int quizId)
+    {
+        var quizQuestions = await _unitOfWork.QuizQuestions
+            .Get(i => i.QuizId == quizId, includes: q => q.PossibleAnswers);
+        return quizQuestions.Select(i => new QuizQuestionDto(i)).ToList();
+    }
+}

--- a/server/src/Domain/Constraints/QuizConstraints.cs
+++ b/server/src/Domain/Constraints/QuizConstraints.cs
@@ -1,0 +1,7 @@
+﻿namespace StudyZen.Domain.Constraints;
+public static class QuizConstraints
+{
+    public const int TitleMaxLength = 250;
+    public const int QuestionMaxLength = 250;
+    public const int AnswerMaxLength = 250;
+}

--- a/server/src/Domain/Entities/AuditableEntity.cs
+++ b/server/src/Domain/Entities/AuditableEntity.cs
@@ -1,0 +1,18 @@
+﻿using StudyZen.Domain.Interfaces;
+using StudyZen.Domain.ValueObjects;
+using System.ComponentModel.DataAnnotations;
+
+namespace StudyZen.Domain.Entities;
+
+public abstract class AuditableEntity : BaseEntity, IAuditable
+{
+    [Required]
+    public UserActionStamp CreatedBy { get; set; } = null!;
+
+    [Required]
+    public UserActionStamp UpdatedBy { get; set; } = null!;
+
+    protected AuditableEntity(int id = default) : base(id)
+    {
+    }
+}

--- a/server/src/Domain/Entities/BaseEntity.cs
+++ b/server/src/Domain/Entities/BaseEntity.cs
@@ -1,21 +1,15 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using StudyZen.Domain.Interfaces;
-using StudyZen.Domain.ValueObjects;
 
 namespace StudyZen.Domain.Entities;
 
-public abstract class BaseEntity : IAuditable
+public abstract class BaseEntity
 {
     [Key]
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; }
 
-    public UserActionStamp CreatedBy { get; set; } = null!;
-
-    public UserActionStamp UpdatedBy { get; set; } = null!;
-
-    protected BaseEntity(int id)
+    protected BaseEntity(int id = default)
     {
         Id = id;
     }

--- a/server/src/Domain/Entities/Course.cs
+++ b/server/src/Domain/Entities/Course.cs
@@ -2,7 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 namespace StudyZen.Domain.Entities;
 
-public sealed class Course : BaseEntity
+public sealed class Course : AuditableEntity
 {
     [Required]
     [StringLength(CourseConstraints.NameMaxLength)]
@@ -14,7 +14,7 @@ public sealed class Course : BaseEntity
 
     public List<Lecture> Lectures { get; set; } = new();
 
-    public Course(string name, string description) : base(default)
+    public Course(string name, string description)
     {
         Name = name;
         Description = description;

--- a/server/src/Domain/Entities/Flashcard.cs
+++ b/server/src/Domain/Entities/Flashcard.cs
@@ -22,7 +22,7 @@ public sealed class Flashcard : BaseEntity
     [StringLength(FlashcardConstraints.BackMaxLength)]
     public string Back { get; set; }
 
-    public Flashcard(int flashcardSetId, string front, string back) : base(default)
+    public Flashcard(int flashcardSetId, string front, string back)
     {
         FlashcardSetId = flashcardSetId;
         Front = front;

--- a/server/src/Domain/Entities/FlashcardSet.cs
+++ b/server/src/Domain/Entities/FlashcardSet.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations;
 
 namespace StudyZen.Domain.Entities;
 
-public sealed class FlashcardSet : BaseEntity
+public sealed class FlashcardSet : AuditableEntity
 {
     public int? LectureId { get; set; }
 
@@ -21,7 +21,7 @@ public sealed class FlashcardSet : BaseEntity
 
     public List<Flashcard> Flashcards { get; set; } = new();
 
-    public FlashcardSet(int? lectureId, string name, Color color) : base(default)
+    public FlashcardSet(int? lectureId, string name, Color color)
     {
         LectureId = lectureId;
         Name = name;

--- a/server/src/Domain/Entities/Lecture.cs
+++ b/server/src/Domain/Entities/Lecture.cs
@@ -4,7 +4,7 @@ using StudyZen.Domain.Constraints;
 
 namespace StudyZen.Domain.Entities;
 
-public sealed class Lecture : BaseEntity
+public sealed class Lecture : AuditableEntity
 {
     [Required]
     public int CourseId { get; set; }
@@ -12,7 +12,6 @@ public sealed class Lecture : BaseEntity
     [Required]
     [ForeignKey(nameof(CourseId))]
     public Course Course { get; set; } = null!;
-
 
     [Required]
     [StringLength(LectureConstraints.NameMaxLength)]
@@ -24,7 +23,7 @@ public sealed class Lecture : BaseEntity
 
     public List<FlashcardSet> FlashcardSets { get; set; } = new();
 
-    public Lecture(int courseId, string name, string content) : base(default)
+    public Lecture(int courseId, string name, string content)
     {
         CourseId = courseId;
         Name = name;

--- a/server/src/Domain/Entities/Quiz.cs
+++ b/server/src/Domain/Entities/Quiz.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel.DataAnnotations;
+using StudyZen.Domain.Constraints;
+
+namespace StudyZen.Domain.Entities;
+
+public sealed class Quiz : AuditableEntity
+{
+    [Required]
+    [StringLength(QuizConstraints.TitleMaxLength)]
+    public string Title { get; set; }
+
+    public List<QuizQuestion> Questions { get; set; } = new();
+
+    public Quiz(string title)
+    {
+        Title = title;
+    }
+}

--- a/server/src/Domain/Entities/QuizAnswer.cs
+++ b/server/src/Domain/Entities/QuizAnswer.cs
@@ -1,0 +1,20 @@
+﻿using StudyZen.Domain.Constraints;
+using System.ComponentModel.DataAnnotations;
+
+namespace StudyZen.Domain.Entities;
+
+public sealed class QuizAnswer : BaseEntity
+{
+    [Required]
+    public int QuizQuestionId { get; set; }
+
+    [Required]
+    [StringLength(QuizConstraints.AnswerMaxLength)]
+    public string Answer { get; set; }
+
+    public QuizAnswer(int quizQuestionId, string answer)
+    {
+        Answer = answer;
+        QuizQuestionId = quizQuestionId;
+    }
+}

--- a/server/src/Domain/Entities/QuizQuestion.cs
+++ b/server/src/Domain/Entities/QuizQuestion.cs
@@ -1,0 +1,35 @@
+﻿using StudyZen.Domain.Constraints;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace StudyZen.Domain.Entities;
+
+public sealed class QuizQuestion : BaseEntity
+{
+    [Required]
+    [StringLength(QuizConstraints.QuestionMaxLength)]
+    public string Question { get; set; }
+
+    [Required]
+    public int QuizId { get; set; }
+
+    [Required]
+    [ForeignKey(nameof(QuizId))]
+    public Quiz Quiz { get; set; } = null!;
+
+    public int? CorrectAnswerId { get; set; }
+
+    public QuizAnswer? CorrectAnswer { get; set; } = null!;
+
+    public List<QuizAnswer> PossibleAnswers { get; set; } = new();
+
+    [Required]
+    public TimeSpan TimeLimit { get; set; }
+
+    public QuizQuestion(int quizId, string question, TimeSpan timeLimit)
+    {
+        QuizId = quizId;
+        Question = question;
+        TimeLimit = timeLimit;
+    }
+}

--- a/server/src/Domain/ValueObjects/UserActionStamp.cs
+++ b/server/src/Domain/ValueObjects/UserActionStamp.cs
@@ -1,21 +1,14 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.EntityFrameworkCore;
 
-
 namespace StudyZen.Domain.ValueObjects;
+
 [Owned]
-public record UserActionStamp
+public sealed record UserActionStamp(string User, DateTime Timestamp)
 {
     [Required]
-    public string User { get; set; }
+    public string User { get; set; } = User;
 
     [Required]
-    public DateTime Timestamp { get; set; }
-
-
-    public UserActionStamp(string user, DateTime timestamp)
-    {
-        User = user;
-        Timestamp = timestamp;
-    }
+    public DateTime Timestamp { get; set; } = Timestamp;
 }

--- a/server/src/Infrastructure/DependencyInjection.cs
+++ b/server/src/Infrastructure/DependencyInjection.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.Extensions.DependencyInjection;
-using StudyZen.Application.Repositories;
-using Microsoft.EntityFrameworkCore;
-using StudyZen.Infrastructure.Persistence;
+﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using StudyZen.Application.Repositories;
+using StudyZen.Infrastructure.Persistence;
 
 namespace StudyZen.Infrastructure;
 
@@ -16,6 +16,9 @@ public static class DependencyInjection
         services.AddScoped<ILectureRepository, LectureRepository>();
         services.AddScoped<IFlashcardRepository, FlashcardRepository>();
         services.AddScoped<IFlashcardSetRepository, FlashcardSetRepository>();
+        services.AddScoped<IQuizRepository, QuizRepository>();
+        services.AddScoped<IQuizQuestionRepository, QuizQuestionRepository>();
+        services.AddScoped<IQuizAnswerRepository, QuizAnswerRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();
 
         return services;

--- a/server/src/Infrastructure/Migrations/20231102062330_AddQuizzes.Designer.cs
+++ b/server/src/Infrastructure/Migrations/20231102062330_AddQuizzes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using StudyZen.Infrastructure.Persistence;
 
@@ -11,9 +12,11 @@ using StudyZen.Infrastructure.Persistence;
 namespace StudyZen.Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231102062330_AddQuizzes")]
+    partial class AddQuizzes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/server/src/Infrastructure/Migrations/20231102062330_AddQuizzes.cs
+++ b/server/src/Infrastructure/Migrations/20231102062330_AddQuizzes.cs
@@ -1,0 +1,159 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace StudyZen.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddQuizzes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CreatedBy_Timestamp",
+                table: "Flashcards");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedBy_User",
+                table: "Flashcards");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedBy_Timestamp",
+                table: "Flashcards");
+
+            migrationBuilder.DropColumn(
+                name: "UpdatedBy_User",
+                table: "Flashcards");
+
+            migrationBuilder.CreateTable(
+                name: "Quizzes",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Title = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    CreatedBy_User = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedBy_Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    UpdatedBy_User = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    UpdatedBy_Timestamp = table.Column<DateTime>(type: "datetime2", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Quizzes", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "QuizAnswers",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    QuizQuestionId = table.Column<int>(type: "int", nullable: false),
+                    Answer = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuizAnswers", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "QuizQuestions",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Question = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    QuizId = table.Column<int>(type: "int", nullable: false),
+                    CorrectAnswerId = table.Column<int>(type: "int", nullable: true),
+                    TimeLimit = table.Column<TimeSpan>(type: "time", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_QuizQuestions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_QuizQuestions_QuizAnswers_CorrectAnswerId",
+                        column: x => x.CorrectAnswerId,
+                        principalTable: "QuizAnswers",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_QuizQuestions_Quizzes_QuizId",
+                        column: x => x.QuizId,
+                        principalTable: "Quizzes",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizAnswers_QuizQuestionId",
+                table: "QuizAnswers",
+                column: "QuizQuestionId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizQuestions_CorrectAnswerId",
+                table: "QuizQuestions",
+                column: "CorrectAnswerId",
+                unique: true,
+                filter: "[CorrectAnswerId] IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_QuizQuestions_QuizId",
+                table: "QuizQuestions",
+                column: "QuizId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_QuizAnswers_QuizQuestions_QuizQuestionId",
+                table: "QuizAnswers",
+                column: "QuizQuestionId",
+                principalTable: "QuizQuestions",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_QuizAnswers_QuizQuestions_QuizQuestionId",
+                table: "QuizAnswers");
+
+            migrationBuilder.DropTable(
+                name: "QuizQuestions");
+
+            migrationBuilder.DropTable(
+                name: "QuizAnswers");
+
+            migrationBuilder.DropTable(
+                name: "Quizzes");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedBy_Timestamp",
+                table: "Flashcards",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "CreatedBy_User",
+                table: "Flashcards",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "UpdatedBy_Timestamp",
+                table: "Flashcards",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "UpdatedBy_User",
+                table: "Flashcards",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/server/src/Infrastructure/Persistence/ApplicationDbContext.cs
+++ b/server/src/Infrastructure/Persistence/ApplicationDbContext.cs
@@ -10,8 +10,18 @@ public class ApplicationDbContext : DbContext
     public DbSet<Course> Courses { get; set; } = null!;
     public DbSet<Flashcard> Flashcards { get; set; } = null!;
     public DbSet<FlashcardSet> FlashcardSets { get; set; } = null!;
+    public DbSet<Quiz> Quizzes { get; set; } = null!;
+    public DbSet<QuizQuestion> QuizQuestions { get; set; } = null!;
+    public DbSet<QuizAnswer> QuizAnswers { get; set; } = null!;
 
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options)
     {
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.ApplyConfigurationsFromAssembly(Assembly.GetExecutingAssembly());
+
+        base.OnModelCreating(modelBuilder);
     }
 }

--- a/server/src/Infrastructure/Persistence/Configurations/QuizQuestionConfiguration.cs
+++ b/server/src/Infrastructure/Persistence/Configurations/QuizQuestionConfiguration.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using StudyZen.Domain.Entities;
+
+namespace StudyZen.Infrastructure.Persistence;
+public sealed class QuizQuestionConfiguration : IEntityTypeConfiguration<QuizQuestion>
+{
+    public void Configure(EntityTypeBuilder<QuizQuestion> builder)
+    {
+        builder
+            .HasMany(q => q.PossibleAnswers)
+            .WithOne()
+            .HasForeignKey(a => a.QuizQuestionId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder
+            .HasOne(q => q.CorrectAnswer)
+            .WithOne()
+            .HasForeignKey<QuizQuestion>(q => q.CorrectAnswerId);
+    }
+}

--- a/server/src/Infrastructure/Persistence/Repositories/QuizAnswerRepository.cs
+++ b/server/src/Infrastructure/Persistence/Repositories/QuizAnswerRepository.cs
@@ -1,0 +1,11 @@
+﻿using StudyZen.Application.Repositories;
+using StudyZen.Domain.Entities;
+
+namespace StudyZen.Infrastructure.Persistence;
+
+public sealed class QuizAnswerRepository : Repository<QuizAnswer>, IQuizAnswerRepository
+{
+    public QuizAnswerRepository(ApplicationDbContext dbContext) : base(dbContext)
+    {
+    }
+}

--- a/server/src/Infrastructure/Persistence/Repositories/QuizQuestionRepository.cs
+++ b/server/src/Infrastructure/Persistence/Repositories/QuizQuestionRepository.cs
@@ -1,0 +1,11 @@
+﻿using StudyZen.Application.Repositories;
+using StudyZen.Domain.Entities;
+
+namespace StudyZen.Infrastructure.Persistence;
+
+public sealed class QuizQuestionRepository : Repository<QuizQuestion>, IQuizQuestionRepository
+{
+    public QuizQuestionRepository(ApplicationDbContext dbContext) : base(dbContext)
+    {
+    }
+}

--- a/server/src/Infrastructure/Persistence/Repositories/QuizRepository.cs
+++ b/server/src/Infrastructure/Persistence/Repositories/QuizRepository.cs
@@ -1,0 +1,11 @@
+﻿using StudyZen.Application.Repositories;
+using StudyZen.Domain.Entities;
+
+namespace StudyZen.Infrastructure.Persistence;
+
+public sealed class QuizRepository : Repository<Quiz>, IQuizRepository
+{
+    public QuizRepository(ApplicationDbContext dbContext) : base(dbContext)
+    {
+    }
+}

--- a/server/src/Infrastructure/Persistence/Repositories/UnitOfWork.cs
+++ b/server/src/Infrastructure/Persistence/Repositories/UnitOfWork.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using StudyZen.Application.Repositories;
 
 namespace StudyZen.Infrastructure.Persistence;
@@ -12,6 +13,9 @@ public sealed class UnitOfWork : IUnitOfWork
     public ILectureRepository Lectures { get; }
     public IFlashcardSetRepository FlashcardSets { get; }
     public IFlashcardRepository Flashcards { get; }
+    public IQuizRepository Quizzes { get; }
+    public IQuizQuestionRepository QuizQuestions { get; }
+    public IQuizAnswerRepository QuizAnswers { get; }
 
     // TODO: change these to save changes interceptors after lab 2
     // https://learn.microsoft.com/en-us/ef/core/logging-events-diagnostics/interceptors
@@ -23,7 +27,10 @@ public sealed class UnitOfWork : IUnitOfWork
         ICourseRepository courses,
         ILectureRepository lectures,
         IFlashcardSetRepository flashcardSets,
-        IFlashcardRepository flashcards)
+        IFlashcardRepository flashcards,
+        IQuizRepository quizzes,
+        IQuizQuestionRepository quizQuestions, 
+        IQuizAnswerRepository quizAnswers)
     {
         _dbContext = dbContext;
 
@@ -31,6 +38,9 @@ public sealed class UnitOfWork : IUnitOfWork
         Lectures = lectures;
         FlashcardSets = flashcardSets;
         Flashcards = flashcards;
+        Quizzes = quizzes;
+        QuizQuestions = quizQuestions;
+        QuizAnswers = quizAnswers;
 
         OnInstanceAdded += AuditableEntityInterceptor.SetCreateStamp;
         OnInstanceUpdated += AuditableEntityInterceptor.SetUpdateStamp;
@@ -54,6 +64,8 @@ public sealed class UnitOfWork : IUnitOfWork
 
         return await _dbContext.SaveChangesAsync();
     }
+
+    public IDbContextTransaction BeginTransaction() => _dbContext.Database.BeginTransaction();
 
     public void Dispose()
     {


### PR DESCRIPTION
- Added initial implementation for quizzes; will work on creating quiz games next week
- Had to make separate configuration file for QuizQuestion because EF Core could not create foreign keys for Question -> PossibleAnswers and Question -> CorrectAnswer from data annotations (similar stuff to this https://stackoverflow.com/questions/40073149/entity-framework-circular-dependency-for-last-entity)
- Added src and tests solution folders for VS
- Separated BaseEntity and AuditableEntity; removed user action stamps from flashcard as it uses more data than the actual flashcard